### PR TITLE
Null terminate public strings

### DIFF
--- a/httputils.nim
+++ b/httputils.nim
@@ -547,8 +547,6 @@ proc toString(data: openarray[byte], start, stop: int): string =
   ## Slice a raw data blob into a string
   ## This is an inclusive slice
   ## The output string is null-terminated for raw C-compat
-  assert stop in start ..< data.len
-
   let len = stop - start + 1
   result = newString(len)
   copyMem(result[0].addr, data[start].unsafeAddr, len)

--- a/httputils.nim
+++ b/httputils.nim
@@ -547,12 +547,9 @@ proc toString(data: openarray[byte], start, stop: int): string =
   ## Slice a raw data blob into a string
   ## This is an inclusive slice
   ## The output string is null-terminated for raw C-compat
-  assert start in 0 ..< data.len
-  assert stop in 0 ..< data.len
+  assert stop in start ..< data.len
 
   let len = stop - start + 1
-  assert len in 0 ..< data.len
-
   result = newString(len)
   copyMem(result[0].addr, data[start].unsafeAddr, len)
 

--- a/tests/tvectors.nim
+++ b/tests/tvectors.nim
@@ -333,6 +333,10 @@ suite "HTTP Procedures test suite":
         check:
           req.success() == true
           req.uri() == RequestUris[i]
+          block: # Check null-termination for cstring compat
+            let uri = req.uri()
+            let puri = cast[ptr UncheckedArray[char]](uri[0].unsafeAddr)
+            puri[uri.len] == '\0'
           req.version == RequestVersions[i]
           len(req) == RequestHeaders[i][1] - RequestHeaders[i][0] + 1
           req.contentLength() == RequestCLengths[i]


### PR DESCRIPTION
This ensures that public strings are null-terminated so that they can be passed as-is to raw C routines.
It fixes #8 

In terms of performance we have for `request.data.toString(request.url.s, request.url.e)`:
- allocation of a string of length L (+1 for null byte)
- copyMem of a slice of length L

The original code `cast[string](request.data[request.url.s..request.url.e])` had
- allocation of a `seq[byte]` of length L
- copyMem of a byte slice of length L
- reinterpreting the memory

So we should be as efficient.